### PR TITLE
Differentiate "predigt" and "archive"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,19 @@ Dann kann man die `.bat` ausführen.<br>
 
 Die ersten 15 Zeilen sind nur dazu da, dass [FFmpeg](https://ffmpeg.org/) installiert wird, mit dem ich die Konvertierung mache.<br>
 
-Die konvertierten Dateien landen dann im Ordner von dem Tag unter `mp3`. Das sollte man aber relativ leicht ändern können, wenn man alle an einem Ort haben wollen würde.<br>
+Die konvertierten Dateien landen dann im Ordner von dem Tag unter `archiv`. Das sollte man aber relativ leicht ändern können, wenn man alle an einem Ort haben wollen würde. Zusätzlich wird ein Ordner `predigt` erstellt, in dem sich nur die Predigt befindet. <br>
 Beispiel:<br>
 <pre><code>root
 ├── 2023.08.27
 │   ├── 001.wav
 │   ├── 002.wav
 │   ├── 003.wav
-│   └── mp3
+│   └── archiv
 │       ├── 20230827_1.mp3
 │       ├── 20230827_2.mp3
 │       └── 20230827_3.mp3
+│   └── predigt
+│       └── 20230827.mp3
 │ .
 │ .
 │ .

--- a/convert_wav_to_mp3.ps1
+++ b/convert_wav_to_mp3.ps1
@@ -24,21 +24,13 @@ foreach ($folder in $folders)
 	$wavs_all = Get-ChildItem -Path $folder -File "*.wav"	# store every .wav in the current folder
 	$wavs
 	
-	if ($wavs_all.Count -lt 1)
+	if ($wavs_all.Count -lt 2)					# skip processing in case there are less than two elements
 	{
 		continue
 	}
-	elseif ($wavs_all.Count -lt 3)
-	{
-		$wavs = $wavs_all
-	}
 	else
 	{
-		$wavs = @(
-			$wavs_all[0]                        # 001.wav
-			$wavs_all[1]                        # 002.wav
-			$wavs_all[-1]                       # 008.wav (last file in the list)
-		)
+		$wavs = $wavs_all
 	}
 
 	
@@ -46,16 +38,22 @@ foreach ($folder in $folders)
 	$month = "00"
 	$day = "00"
 
-	$output_path = ".\$($folder)\mp3\"	# .\2023.08.27\mp3\
+	$output_path_archive = ".\$($folder)\archiv\"	# .\2023.08.27\archiv\
+	$output_path_predigt = ".\$($folder)\predigt\"	# .\2023.08.27\predigt\
 
-	if (!(Test-Path -Path $output_path))
+	# create directories for archive and predigt in case they do not already exist
+	if (!(Test-Path -Path $output_path_archive))
 	{
-		mkdir $output_path	# create directory 
+		mkdir $output_path_archive	# create directory 
 	}
 
-	$i = 1
+	if (!(Test-Path -Path $output_path_predigt))
+	{
+		mkdir $output_path_predigt	# create directory 
+	}
 
 	"Converting wav to mp3..."
+	$i = 1
 	foreach ($wav in $wavs)
 	{
 		if ($wav.FullName -match "(?<year>\d{4})\.(?<month>\d{2})\.(?<day>\d{2})")	# regex expression that finds the date in the path of the .wav
@@ -70,14 +68,23 @@ foreach ($folder in $folders)
 			break	# skip to next .wav
 		}
 		
-		$filename = "$($year)$($month)$($day)_$i"	# 20230827_1
-		$i++
+		$filename_archive = "$($year)$($month)$($day)_$i"			# 20230827_1
+		$filename_predigt = "$($year)$($month)$($day)"				# 20230827
 		
-		$in = ".\$($folder)\$($wav)"				# .\2023.08.27\001.wav
-		$out = "$($output_path)$($filename).mp3"	# .\2023.08.27\mp3\20230827_1.mp3
-													# converted files are stored in a folder "mp3" inside every day
+		$in = ".\$($folder)\$($wav)"								# .\2023.08.27\001.wav
+		$out = "$($output_path_archive)$($filename_archive).mp3"	# .\2023.08.27\mp3\20230827_1.mp3
+																	# converted files are stored in a folder "archiv" inside every day
 		
-		ffmpeg -i $in -vn -ar 44100 -ac 2 -b:a 192k $out	# basic conversion
+		ffmpeg -i $in -vn -ar 44100 -ac 2 -b:a 192k $out			# basic conversion
+
+		# assuming that the predigt is the second element, copy it to the respective folder
+		if ($i -eq 2) 
+		{
+			$out_predigt = "$($output_path_predigt)$($filename_predigt).mp3"
+			Copy-Item -Path $out -Destination $out_predigt						# Copy the file and rename it
+		}
+
+		$i++														# increase counter
 	}
 	"Finished converting."
 }

--- a/convert_wav_to_mp3.ps1
+++ b/convert_wav_to_mp3.ps1
@@ -20,12 +20,12 @@ $folders = Get-ChildItem -Path $work_dir -Directory		# store every folder in a l
 
 foreach ($folder in $folders)
 {	
-	"Getting .wavs..."
+	"Getting .wavs inside $folder..."
 	$wavs_all = Get-ChildItem -Path $folder -File "*.wav"	# store every .wav in the current folder
-	$wavs
 	
 	if ($wavs_all.Count -lt 2)					# skip processing in case there are less than two elements
 	{
+		"Too less elements in $folder. No conversion will be done."
 		continue
 	}
 	else
@@ -74,18 +74,25 @@ foreach ($folder in $folders)
 		$in = ".\$($folder)\$($wav)"								# .\2023.08.27\001.wav
 		$out = "$($output_path_archive)$($filename_archive).mp3"	# .\2023.08.27\mp3\20230827_1.mp3
 																	# converted files are stored in a folder "archiv" inside every day
-		
-		ffmpeg -i $in -vn -ar 44100 -ac 2 -b:a 192k $out			# basic conversion
+
+		if (!(Test-Path -Path $out)){
+			"Converting $in to $out..."
+			ffmpeg -i $in -vn -ar 44100 -ac 2 -b:a 192k $out > $null 2>&1	# basic conversion
+		}
 
 		# assuming that the predigt is the second element, copy it to the respective folder
 		if ($i -eq 2) 
 		{
 			$out_predigt = "$($output_path_predigt)$($filename_predigt).mp3"
-			Copy-Item -Path $out -Destination $out_predigt						# Copy the file and rename it
+			if (!(Test-Path -Path $out_predigt))
+			{
+				"Copy $out to $out_predigt..."
+				Copy-Item -Path $out -Destination $out_predigt		# Copy the file and rename it
+			}
 		}
 
 		$i++														# increase counter
 	}
-	"Finished converting."
+	"Finished converting for $folder."
 }
 


### PR DESCRIPTION
changes:
- create two subfolders `predigt` and `archive` instead of only one folder `mp3`
- `predigt` does only contain one .mp3, whereas `archive` contains all .mp3 files
- adapt naming convention for predigt
- adapt the readme